### PR TITLE
Update various doc index files for nxos_upgrade

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -331,6 +331,7 @@ execution modules
     nspawn
     nxos
     nxos_api
+    nxos_upgrade
     omapi
     openbsd_sysctl
     openbsdpkg

--- a/doc/ref/modules/all/salt.modules.nxos_upgrade.rst
+++ b/doc/ref/modules/all/salt.modules.nxos_upgrade.rst
@@ -1,0 +1,5 @@
+salt.modules.nxos_upgrade module
+============================
+
+.. automodule:: salt.modules.nxos_upgrade
+    :members:

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -224,6 +224,7 @@ state modules
     npm
     ntp
     nxos
+    nxos_upgrade
     openstack_config
     openvswitch_bridge
     openvswitch_port

--- a/doc/ref/states/all/salt.states.nxos_upgrade.rst
+++ b/doc/ref/states/all/salt.states.nxos_upgrade.rst
@@ -1,0 +1,5 @@
+salt.states.nxos_upgrade module
+=======================
+
+.. automodule:: salt.states.nxos_upgrade
+    :members:


### PR DESCRIPTION
### What does this PR do?
This PR updates the various `/doc/ref` files for the `nxos_upgrade` execution module and state.


### Tests written?

No, but the existing tests now pass.

Results:

```bash
(salt_py375) ➜  mike_salt git:(mike-doc-updates) ✗ nox -e 'runtests-zeromq-3(coverage=True)' -- -n unit.test_doc.DocTestCase.test_states_doc_files
nox > Running session runtests-zeromq-3(coverage=True)
nox > Re-using existing virtualenv at .nox/runtests-zeromq-3-coverage-true.
nox > Session runtests-zeromq-3(coverage=True) was successful.
nox > Running session runtests-parametrized-3(coverage=True, crypto=None, transport='zeromq')
nox > Re-using existing virtualenv at .nox/runtests-parametrized-3-coverage-true-crypto-none-transport-zeromq.
nox > Processing pkg/osx/req.txt
nox > Processing pkg/osx/req_ext.txt
nox > Processing pkg/osx/req_pyobjc.txt
nox > Processing requirements/static/darwin.in
nox > pip install --progress-bar=off -r requirements/base.txt --constraint requirements/static/py3.7/darwin.txt --constraint requirements/static/py3.7/darwin-crypto.txt
nox > pip install --progress-bar=off -r requirements/zeromq.txt --constraint requirements/static/py3.7/darwin.txt --constraint requirements/static/py3.7/darwin-crypto.txt
nox > pip install --progress-bar=off -r requirements/pytest.txt --constraint requirements/static/py3.7/darwin.txt --constraint requirements/static/py3.7/darwin-crypto.txt
nox > pip install --progress-bar=off -r pkg/osx/req.txt --constraint requirements/static/py3.7/darwin.txt --constraint requirements/static/py3.7/darwin-crypto.txt
nox > pip install --progress-bar=off -r pkg/osx/req_ext.txt --constraint requirements/static/py3.7/darwin.txt --constraint requirements/static/py3.7/darwin-crypto.txt
nox > pip install --progress-bar=off -r pkg/osx/req_pyobjc.txt --constraint requirements/static/py3.7/darwin.txt --constraint requirements/static/py3.7/darwin-crypto.txt
nox > pip install --progress-bar=off -r requirements/static/darwin.in --constraint requirements/static/py3.7/darwin.txt --constraint requirements/static/py3.7/darwin-crypto.txt
nox > pip install --progress-bar=off --constraint requirements/static/py3.7/darwin.txt --constraint requirements/static/py3.7/darwin-crypto.txt unittest-xml-reporting==2.5.2
nox > pip install --progress-bar=off coverage==5.0.1
nox > coverage erase
nox > coverage run tests/runtests.py --tests-logfile=artifacts/logs/runtests-20200427163745.637589.log --transport=zeromq -n unit.test_doc.DocTestCase.test_states_doc_files
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Python Version: 3.7.5 (default, Apr 3 2020, 08:45:14) [Clang 11.0.3 (clang-1103.0.32.29)]
 * Transplanting configuration files to '/private/tmp/salt-tests-tmpdir/config'
 * Transplanting multimaster configuration files to '/private/tmp/salt-tests-tmpdir/config'
 * Current Directory: /Users/mwiebe/Projects/Salt/mike_salt
 * Test suite is running under PID 76500
 * Logging tests on artifacts/logs/runtests-20200427163745.637589.log
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Starting unit.test_doc.DocTestCase.test_states_doc_files Tests
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.
----------------------------------------------------------------------
Ran 1 test in 0.092s

OK

========================================================================================================  Overall Tests Report  =========================================================================================================
***  No Problems Found While Running Tests  *********************************************************************************************************************************************************************************************
=========================================================================================================================================================================================================================================
OK (total=1, skipped=0, passed=1, failures=0, errors=0)
========================================================================================================  Overall Tests Report  =========================================================================================================
Test suite execution finalized with exit code: 0
nox > coverage combine
nox > coverage xml -o artifacts/coverage/salt.xml --omit=tests/* --include=salt/*
nox > coverage xml -o artifacts/coverage/tests.xml --omit=salt/* --include=tests/*
nox > Session runtests-parametrized-3(coverage=True, crypto=None, transport='zeromq') was successful.
nox > Ran multiple sessions:
nox > * runtests-zeromq-3(coverage=True): success
nox > * runtests-parametrized-3(coverage=True, crypto=None, transport='zeromq'): success
(salt_py375) ➜  mike_salt git:(mike-doc-updates) ✗
```