### PR TITLE
Fix a few bugs in nxos proxy and execution modules

### DIFF
--- a/salt/modules/nxos.py
+++ b/salt/modules/nxos.py
@@ -343,6 +343,8 @@ def sendline(command, method="cli_show_ascii", **kwargs):
     .. code-block: bash
 
         salt '*' nxos.sendline 'show run | include "^username admin password"'
+        salt '*' nxos.sendline "['show inventory', 'show version']"
+        salt '*' nxos.sendline 'show inventory ; show version'
     """
     smethods = ["cli_show_ascii", "cli_show", "cli_conf"]
     if method not in smethods:

--- a/salt/proxy/nxos.py
+++ b/salt/proxy/nxos.py
@@ -392,10 +392,10 @@ def _shutdown_ssh():
     return "Shutdown of ssh proxy minion is not supported"
 
 
-def _sendline_ssh(commands, **kwargs):
+def _sendline_ssh(commands, timeout=None, **kwargs):
     if isinstance(commands, str):
         commands = [commands]
-    command = "; ".join(commands)
+    command = " ; ".join(commands)
     if _ping_ssh() is False:
         _init_ssh()
     out, err = DEVICE_DETAILS[_worker_name()].sendline(command)
@@ -406,7 +406,7 @@ def _sendline_ssh(commands, **kwargs):
     return out
 
 
-def _parse_output_for_errors(data, command, **kwargs):
+def _parse_output_for_errors(data, command, error_pattern=None):
     """
     Helper method to parse command output for error information
     """
@@ -419,8 +419,7 @@ def _parse_output_for_errors(data, command, **kwargs):
                 "cli_error": data.lstrip(),
             }
         )
-    if kwargs.get("error_pattern"):
-        error_pattern = kwargs.get("error_pattern")
+    if error_pattern:
         if isinstance(error_pattern, str):
             error_pattern = [error_pattern]
         for re_line in error_pattern:


### PR DESCRIPTION
### What does this PR do?

* Add examples for using `nxos.sendline` function with a list of commands.
* Adds explicit `timeout` function argument to `_sendline_ssh` function to avoid passing `kwargs` to `_parse_output_for_errors`.

### Tests written?

No

### Commits signed with GPG?

No, but existing unit tests run/passing and manual integration tests executed.